### PR TITLE
Adding read_temperature

### DIFF
--- a/library/icm20948/__init__.py
+++ b/library/icm20948/__init__.py
@@ -34,6 +34,14 @@ ICM20948_ACCEL_CONFIG = 0x14
 ICM20948_ACCEL_XOUT_H = 0x2D
 ICM20948_GRYO_XOUT_H = 0x33
 
+ICM20948_TEMP_OUT_H = 0x39
+ICM20948_TEMP_OUT_L = 0x3A
+
+# Offset and sensitivity - defined in electrical characteristics, and TEMP_OUT_H/L of datasheet
+ICM20948_TEMPERATURE_DEGREES_OFFSET = 21
+ICM20948_TEMPERATURE_SENSITIVITY = 333.87
+ICM20948_ROOM_TEMP_OFFSET = 21
+
 AK09916_I2C_ADDR = 0x0c
 AK09916_CHIP_ID = 0x09
 AK09916_WIA = 0x01
@@ -209,6 +217,15 @@ class ICM20948:
         value |= (mode & 0x07) << 4
         self.write(ICM20948_GYRO_CONFIG_1, value)
 
+    def read_temperature(self):
+        """Property to read the current IMU temperature"""
+        # PWR_MGMT_1 defaults to leave temperature enabled
+        self.bank(0)
+        temp_raw_bytes = self.read_bytes(ICM20948_TEMP_OUT_H, 2)
+        temp_raw = struct.unpack('>h', bytearray(temp_raw_bytes))[0]
+        temperature_deg_c = ((temp_raw - ICM20948_ROOM_TEMP_OFFSET) / ICM20948_TEMPERATURE_SENSITIVITY) + ICM20948_TEMPERATURE_DEGREES_OFFSET
+        return temperature_deg_c
+    
     def __init__(self, i2c_addr=I2C_ADDR, i2c_bus=None):
         self._bank = -1
         self._addr = i2c_addr

--- a/library/tests/test_read.py
+++ b/library/tests/test_read.py
@@ -22,4 +22,4 @@ def test_temperature():
     from icm20948 import ICM20948
     icm20948 = ICM20948()
     temp_degrees = icm20948.read_temperature()
-    assert (round(temp_degrees, 2) = 24)
+    assert (round(temp_degrees, 2) == 24)

--- a/library/tests/test_read.py
+++ b/library/tests/test_read.py
@@ -13,3 +13,13 @@ def test_accel_gyro():
     ax, ay, az, gx, gy, gz = icm20948.read_accelerometer_gyro_data()
     assert (round(ax, 2), round(ay, 2), round(az, 2), int(gx), int(gy), int(gz)) == (0.05, 0.11, 0.16, 3, 4, 5)
     del icm20948
+
+def test_temperature():
+    smbus = mock.Mock()
+    smbus.SMBus = MockSMBus
+    sys.modules['smbus'] = smbus
+
+    from icm20948 import ICM20948
+    icm20948 = ICM20948()
+    temp_degrees = icm20948.read_temperature()
+    assert (round(temp_degrees, 2) = 24)

--- a/library/tests/tools.py
+++ b/library/tests/tools.py
@@ -36,4 +36,4 @@ class MockSMBus():
             ))
         # temperature data
         if length == 2:
-            return struct.pack(">h", *(0x4, 0x00))
+            return struct.pack(">h", *(0x4, 0x02))

--- a/library/tests/tools.py
+++ b/library/tests/tools.py
@@ -34,3 +34,6 @@ class MockSMBus():
                 555,
                 666
             ))
+        # temperature data
+        if length == 2:
+            return struct.pack(">h", *(0x4, 0x00))

--- a/library/tests/tools.py
+++ b/library/tests/tools.py
@@ -36,4 +36,4 @@ class MockSMBus():
             ))
         # temperature data
         if length == 2:
-            return struct.pack(">h", *(0x4, 0x02))
+            return struct.pack(">h", 0x400)


### PR DESCRIPTION
Adding a getter that reads the temperature, based on numbers from the datasheet. The 21's happen to be the same but are separately defined in the formula, so should be separate constants. 

It is a read, and not a property since it does have to fetch registers from the device.