### PR TITLE
Fix pwr mgmt for magnetometer

### DIFF
--- a/library/icm20948/__init__.py
+++ b/library/icm20948/__init__.py
@@ -238,6 +238,8 @@ class ICM20948:
         if not self.read(ICM20948_WHO_AM_I) == CHIP_ID:
             raise RuntimeError("Unable to find ICM20948")
 
+        self.write(ICM20948_PWR_MGMT_1, 0x80)
+        time.sleep(0.01)
         self.write(ICM20948_PWR_MGMT_1, 0x01)
         self.write(ICM20948_PWR_MGMT_2, 0x00)
 


### PR DESCRIPTION
The original C code supplied by Waveshare with their IMX219-83 stereo camera including an icm20948 9dof sensor includes this additional write for power management. Without it, the magnetometer won't be ready on the waveshare device: It'll be stuck at `while not self.magnetometer_ready()` forever.

Moreover, the fix by @Gadgetoid makes the magnetometer output meaningful data. Applying the power management fix to current master (without the changes in branch `patch-mag-io`), there is data from the magnetometer, but it sometimes (approximately once per second) spikes to values 1000 times higher than before.

Thus it seems both fixes are necessary to get the Waveshare sensor work.