### PR TITLE
Change to the library directory to build the docs when running install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -236,6 +236,8 @@ fi
 
 printf "\n"
 
+cd library
+
 if [ -f "/usr/bin/pydoc" ]; then
 	printf "Generating documentation.\n"
 	pydoc -w $LIBRARY_NAME > /dev/null


### PR DESCRIPTION
An error occurs when running `sudo ./install.sh` from the working directory:

```
Generating documentation.
Error: Failed to generate documentation.
```

This can be fixed by changing to the library directory before running pydoc.